### PR TITLE
support aarch64 architecture.

### DIFF
--- a/src/ffmpeg_downloader/_linux.py
+++ b/src/ffmpeg_downloader/_linux.py
@@ -18,8 +18,7 @@ mapping = {
 
 # place the matching cpu arch first (need test)
 arch = platform.machine()
-if arch in mapping:
-    arch = mapping[arch]
+arch = mapping.get(arch, arch) # resolve alias
 try:
     # TODO - adjust as feedback for different architecture is provided
     i = asset_priority.index(arch)

--- a/src/ffmpeg_downloader/_linux.py
+++ b/src/ffmpeg_downloader/_linux.py
@@ -12,9 +12,14 @@ home_url = "https://johnvansickle.com/ffmpeg"
 
 # last one gets picked
 asset_priority = ["amd64", "i686", "arm64", "armhf", "armel"]
+mapping = {
+    "aarch64": "arm64"
+}
 
 # place the matching cpu arch first (need test)
 arch = platform.machine()
+if arch in mapping:
+    arch = mapping[arch]
 try:
     # TODO - adjust as feedback for different architecture is provided
     i = asset_priority.index(arch)


### PR DESCRIPTION
this patch ensures that the correct binaries are downloaded and installed on "aarch64" archtiectures.

The current version 0.2.0 will install the wrong binaries on those architectures.