### PR TITLE
support setting symlinks on macos.

### DIFF
--- a/src/ffmpeg_downloader/_linux.py
+++ b/src/ffmpeg_downloader/_linux.py
@@ -188,20 +188,22 @@ def extract(tarpaths, dst, progress=None):
     return dstsub
 
 
-def set_symlinks(binpaths):
-
-    user_home = path.expanduser("~")
-    user_bindirs = [path.join(user_home, ".local", "bin"), path.join(user_home, "bin")]
-    d = next(
-        (d for d in user_bindirs if path.isdir(d)),
-        None,
-    )
-    if d is None:
-        d = user_bindirs[0]
-        os.makedirs(d, exist_ok=True)
-        print(
-            "!!!Created ~/.local/bin. Must log out and back in for the setting to take effect (or update .profile or .bashrc).!!!"
+def set_symlinks(binpaths, target=None):
+    if target:
+        d = target
+    else:
+        user_home = path.expanduser("~")
+        user_bindirs = [path.join(user_home, ".local", "bin"), path.join(user_home, "bin")]
+        d = next(
+            (d for d in user_bindirs if path.isdir(d)),
+            None,
         )
+        if d is None:
+            d = user_bindirs[0]
+            os.makedirs(d, exist_ok=True)
+            print(
+                "!!!Created ~/.local/bin. Must log out and back in for the setting to take effect (or update .profile or .bashrc).!!!"
+            )
 
     symlinks = {name: path.join(d, name) for name in binpaths}
     for name, binpath in binpaths.items():

--- a/src/ffmpeg_downloader/_macos.py
+++ b/src/ffmpeg_downloader/_macos.py
@@ -1,3 +1,4 @@
+import sys
 from os import path
 import re, os, zipfile
 
@@ -165,7 +166,9 @@ def extract(zippaths, dst, progress=None):
 
 
 def set_symlinks(binpaths):
-    raise NotImplementedError("--set_symlinks option is not supported on Mac")
+    from . import _linux as linux
+    target = path.dirname(sys.executable)
+    linux.set_symlinks(binpaths, target)
 
 
 def clr_symlinks(symlinks):


### PR DESCRIPTION
on macos, the perfered location for the symlinks is the directory where the ffdl binary is installed, since

~/.local/bin is not supported by default.

I did not want to change the behaviour on linux systems as well as anyway reuse the linux version of set_symlinks since it works file on mac, too.