### PR TITLE
Fix dst argument to accept a single value instead of list

### DIFF
--- a/src/ffmpeg_downloader/__main__.py
+++ b/src/ffmpeg_downloader/__main__.py
@@ -350,7 +350,7 @@ def main(prog: str = ""):
     parser_download = subparsers.add_parser("download", help="Download FFmpeg")
     # specify version and build options (version string or 'snapshot') (optional argument), 5.1.2 or 5.1.2@essential or 5.1.2@arm or snapshot
     parser_download.add_argument(
-        "-d", "--dst", nargs=1, help="Download FFmpeg zip/tar file into <DIR>"
+        "-d", "--dst", help="Download FFmpeg zip/tar file into <DIR>"
     )
     parser_download.add_argument(
         "-y", action="store_true", help="Don't ask for confirmation to download."


### PR DESCRIPTION
Specifying `nargs=1` to the argument parser effectively turns the parameter into a list with a single value.

This makes it impossible to specify a destination for the download subcommand as downstream function expect a string and not a list.

```
C:\Users\ucodia\code\myproject> ffdl download 7.1@full -d bin
Traceback (most recent call last):
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\ucodia\miniconda3\envs\myproject\Scripts\ffdl.exe\__main__.py", line 6, in <module>
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\ffdl.py", line 5, in run
    main("ffdl")
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\__main__.py", line 401, in main
    args.func(args)
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\__main__.py", line 80, in download
    dstpaths = ffdl.download(
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\_backend.py", line 205, in download
    return [do(*entry) for entry in info]
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\_backend.py", line 205, in <listcomp>
    return [do(*entry) for entry in info]
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\site-packages\ffmpeg_downloader\_backend.py", line 171, in do
    dstpath = path.join(dst, filename)
  File "C:\Users\ucodia\miniconda3\envs\myproject\lib\ntpath.py", line 105, in join
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not list
```

The simplest fix is to remove the `nargs` specification.

```
C:\Users\ucodia\code\myproject> ffdl download 7.1@full -d bin
Downloaded and saved 7.1@full:
  bin\ffmpeg-7.1.1-full_build.zip
```